### PR TITLE
Split series and spatial DAGs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,7 @@ pub mod dev_utils {
         }
     }
 
-    pub fn construct_fake_dag() -> Dag<&'static str> {
+    pub fn construct_fake_dag() -> ScheduleDag {
         let mut dag: Dag<&'static str> = Dag::new();
 
         let test6 = dag.add_node("test6");
@@ -202,17 +202,30 @@ pub mod dev_utils {
 
         let _test1 = dag.add_node_with_children("test1", vec![test2, test3]);
 
-        dag
+        ScheduleDag {
+            series: Some(dag),
+            spatial: None,
+        }
     }
 
-    pub fn construct_hardcoded_dag() -> Dag<&'static str> {
-        let mut dag: Dag<&'static str> = Dag::new();
+    #[derive(Debug, Clone)]
+    pub struct ScheduleDag {
+        pub series: Option<Dag<&'static str>>,
+        pub spatial: Option<Dag<&'static str>>,
+    }
 
-        dag.add_node("dip_check");
-        dag.add_node("step_check");
-        dag.add_node("buddy_check");
-        dag.add_node("sct");
+    pub fn construct_hardcoded_dag() -> ScheduleDag {
+        let mut series: Dag<&'static str> = Dag::new();
+        series.add_node("dip_check");
+        series.add_node("step_check");
 
-        dag
+        let mut spatial: Dag<&'static str> = Dag::new();
+        spatial.add_node("buddy_check");
+        spatial.add_node("sct");
+
+        ScheduleDag {
+            series: Some(series),
+            spatial: Some(spatial),
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,14 @@ pub mod dev_utils {
         }
     }
 
+    /// A wrapper struct that separates time series and spatial tests
+    /// into two different DAGs
+    #[derive(Debug, Clone)]
+    pub struct ScheduleDag {
+        pub series: Option<Dag<&'static str>>,
+        pub spatial: Option<Dag<&'static str>>,
+    }
+
     pub fn construct_fake_dag() -> ScheduleDag {
         let mut dag: Dag<&'static str> = Dag::new();
 
@@ -206,12 +214,6 @@ pub mod dev_utils {
             series: Some(dag),
             spatial: None,
         }
-    }
-
-    #[derive(Debug, Clone)]
-    pub struct ScheduleDag {
-        pub series: Option<Dag<&'static str>>,
-        pub spatial: Option<Dag<&'static str>>,
     }
 
     pub fn construct_hardcoded_dag() -> ScheduleDag {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,7 @@
 use crate::{
     dag::Dag,
     data_switch::{DataSwitch, GeoPoint, Polygon, Timerange, Timestamp},
+    dev_utils::ScheduleDag,
     pb::{
         rove_server::{Rove, RoveServer},
         ValidateSeriesRequest, ValidateSeriesResponse, ValidateSpatialRequest,
@@ -161,7 +162,7 @@ impl Rove for Scheduler<'static> {
 async fn start_server_inner(
     listener: ListenerType,
     data_switch: DataSwitch<'static>,
-    dag: Dag<&'static str>,
+    dag: ScheduleDag,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let rove_service = Scheduler::new(dag, data_switch);
 
@@ -192,7 +193,7 @@ async fn start_server_inner(
 pub async fn start_server_unix_listener(
     stream: UnixListenerStream,
     data_switch: DataSwitch<'static>,
-    dag: Dag<&'static str>,
+    dag: ScheduleDag,
 ) -> Result<(), Box<dyn std::error::Error>> {
     start_server_inner(ListenerType::UnixListener(stream), data_switch, dag).await
 }
@@ -205,7 +206,7 @@ pub async fn start_server_unix_listener(
 pub async fn start_server(
     addr: SocketAddr,
     data_switch: DataSwitch<'static>,
-    dag: Dag<&'static str>,
+    dag: ScheduleDag,
 ) -> Result<(), Box<dyn std::error::Error>> {
     start_server_inner(ListenerType::Addr(addr), data_switch, dag).await
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,4 @@
 use crate::{
-    dag::Dag,
     data_switch::{DataSwitch, GeoPoint, Polygon, Timerange, Timestamp},
     dev_utils::ScheduleDag,
     pb::{

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,8 +2,8 @@ use core::future::Future;
 use pb::{rove_client::RoveClient, Flag, ValidateSeriesRequest, ValidateSpatialRequest};
 use rove::{
     data_switch::{DataConnector, DataSwitch},
-    dev_utils::{construct_fake_dag, construct_hardcoded_dag, TestDataSource},
-    start_server_unix_listener, Dag,
+    dev_utils::{construct_fake_dag, construct_hardcoded_dag, ScheduleDag, TestDataSource},
+    start_server_unix_listener,
 };
 use std::{collections::HashMap, sync::Arc};
 use tempfile::NamedTempFile;
@@ -21,7 +21,7 @@ const DATA_LEN_SPATIAL: usize = 1000;
 
 pub async fn set_up_rove(
     data_switch: DataSwitch<'static>,
-    dag: Dag<&'static str>,
+    dag: ScheduleDag,
 ) -> (impl Future<Output = ()>, RoveClient<Channel>) {
     let coordintor_socket = NamedTempFile::new().unwrap();
     let coordintor_socket = Arc::new(coordintor_socket.into_temp_path());


### PR DESCRIPTION
- Are both series and spatial tests required? If so, we can drop the `Option` I used in `ScheduleDag`.
  Otherwise, we need to add a check before calling the `validate` methods, to make sure they are not `None`.
  Or when constructing the `subdag`, add something like

  ```rust
  let subdag = Scheduler::construct_subdag(
      self.dag
          .spatial
          .as_ref()
          .ok_or(Error::DagIsNone)?,
      tests,
  )?;
  ```

- Also not sure about the best name and place for `ScheduleDag`.
