### PR TITLE
Merge Series and Spatial caches

### DIFF
--- a/met_connectors/src/frost/mod.rs
+++ b/met_connectors/src/frost/mod.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use chrono::prelude::*;
 use rove::{
     data_switch,
-    data_switch::{DataConnector, Polygon, SeriesCache, SpatialCache, Timerange, Timestamp},
+    data_switch::{DataCache, DataConnector, Polygon, Timerange, Timestamp},
 };
 use serde::{Deserialize, Deserializer};
 use thiserror::Error;
@@ -104,7 +104,7 @@ impl DataConnector for Frost {
         data_id: &str,
         timerange: Timerange,
         num_leading_points: u8,
-    ) -> Result<SeriesCache, data_switch::Error> {
+    ) -> Result<DataCache, data_switch::Error> {
         series::get_series_data_inner(data_id, timerange, num_leading_points).await
     }
 
@@ -113,7 +113,7 @@ impl DataConnector for Frost {
         data_id: &str,
         polygon: &Polygon,
         timestamp: Timestamp,
-    ) -> Result<SpatialCache, data_switch::Error> {
+    ) -> Result<DataCache, data_switch::Error> {
         spatial::get_spatial_data_inner(polygon, data_id, timestamp).await
     }
 }

--- a/met_connectors/src/frost/mod.rs
+++ b/met_connectors/src/frost/mod.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 mod duration;
 mod series;
 mod spatial;
+mod util;
 
 #[derive(Error, Debug)]
 #[non_exhaustive]

--- a/met_connectors/src/frost/util.rs
+++ b/met_connectors/src/frost/util.rs
@@ -1,0 +1,60 @@
+use crate::frost::{duration, Error, FrostLatLonElev, FrostLocation};
+use chrono::prelude::*;
+use chronoutil::RelativeDuration;
+
+pub fn extract_duration(header: &mut serde_json::Value) -> Result<RelativeDuration, Error> {
+    let time_resolution = header
+        .get_mut("extra")
+        .ok_or(Error::FindMetadata(
+            "couldn't find field extra on header".to_string(),
+        ))?
+        .get_mut("timeseries")
+        .ok_or(Error::FindMetadata(
+            "couldn't find field timeseries on extra".to_string(),
+        ))?
+        .get_mut("timeresolution")
+        .ok_or(Error::FindMetadata(
+            "couldn't find field timeresolution on timeseries".to_string(),
+        ))?
+        .as_str()
+        .ok_or(Error::FindMetadata(
+            "field timeresolution was not a string".to_string(),
+        ))?;
+
+    duration::parse_duration(time_resolution).map_err(|e| Error::ParseDuration {
+        source: e,
+        input: time_resolution.to_string(),
+    })
+}
+
+pub fn extract_location(
+    header: &mut serde_json::Value,
+    time: DateTime<Utc>,
+) -> Result<FrostLatLonElev, Error> {
+    let location = header
+        .get_mut("extra")
+        .ok_or(Error::FindLocation(
+            "couldn't find extra in header".to_string(),
+        ))?
+        .get_mut("station")
+        .ok_or(Error::FindLocation(
+            "couldn't find station field in extra".to_string(),
+        ))?
+        .get_mut("location")
+        .ok_or(Error::FindLocation(
+            "couldn't find location field in station".to_string(),
+        ))?
+        .take();
+
+    let loc = serde_json::from_value::<Vec<FrostLocation>>(location)?;
+
+    let lat_lon_elev = loc
+        .into_iter()
+        .find(|l| time > l.from && time < l.to)
+        .ok_or(Error::FindLocation(
+            "couldn't find relevant location for this observation".to_string(),
+        ))?
+        .value;
+
+    Ok(lat_lon_elev)
+}

--- a/met_connectors/src/lustre_netatmo/mod.rs
+++ b/met_connectors/src/lustre_netatmo/mod.rs
@@ -25,9 +25,11 @@ struct Record {
     dqc: u32,
 }
 
-fn read_netatmo(time: Timestamp) -> Result<DataCache, data_switch::Error> {
+fn read_netatmo(timestamp: Timestamp) -> Result<DataCache, data_switch::Error> {
     // timestamp should be validated before it gets here, so it should be safe to unwrap
-    let time = Utc.timestamp_opt(time.0, 0).unwrap();
+    let time = Utc.timestamp_opt(timestamp.0, 0).unwrap();
+    // TODO: time resolution might change in the future
+    let period = RelativeDuration::hours(1);
 
     if time.minute() != 0 || time.second() != 0 {
         return Err(io::Error::new(
@@ -58,18 +60,12 @@ fn read_netatmo(time: Timestamp) -> Result<DataCache, data_switch::Error> {
             lats.push(record.lat);
             lons.push(record.lon);
             elevs.push(record.elev);
-            values.push(Some(record.value));
+            values.push(vec![Some(record.value)]);
         }
     }
 
     Ok(DataCache::new(
-        lats,
-        lons,
-        elevs,
-        Timestamp(0),
-        RelativeDuration::minutes(5),
-        0,
-        vec![values; 1],
+        lats, lons, elevs, timestamp, period, 0, values,
     ))
 }
 

--- a/src/data_switch.rs
+++ b/src/data_switch.rs
@@ -204,7 +204,7 @@ impl DataCache {
 ///             timestamp,
 ///             RelativeDuration::minutes(5),
 ///             0,
-///             vec![vec![Some(1.)], 10]
+///             vec![vec![Some(1.)]; 10]
 ///         ))
 ///     }
 /// }

--- a/src/data_switch.rs
+++ b/src/data_switch.rs
@@ -86,12 +86,12 @@ pub type Polygon = [GeoPoint];
 ///
 /// a [`new`](DataCache::new) method is provided to
 /// avoid the need to construct an R*-tree manually
-// TODO: check why we need to derive PartialEq
+// TODO: check why we needed to derive PartialEq for SeriesCache
 #[derive(Debug, Clone)]
 pub struct DataCache {
     /// Vector of timeseries in chronological order.
     /// The timeseries data can originate from a single station or from
-    /// a collection of them
+    /// a collection of neighboring stations
     ///
     /// `None`s represent gaps in the series
     pub data: Vec<Vec<Option<f32>>>,

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -32,11 +32,14 @@ pub async fn run_test_series(
             // TODO: use actual test params
             // TODO: use par_iter?
 
-            let mut result_vec = Vec::new();
+            let mut result_vec = Vec::with_capacity(cache.data.len());
+
+            // NOTE: Does data in each series have the same len?
+            let series_len = cache.data[0].len();
+
             for i in 0..cache.data.len() {
                 result_vec.push(
-                    cache.data[i]
-                        [(cache.num_leading_points - LEADING_PER_RUN).into()..cache.data[i].len()]
+                    cache.data[i][(cache.num_leading_points - LEADING_PER_RUN).into()..series_len]
                         .windows((LEADING_PER_RUN + 1).into())
                         .map(|window| {
                             olympian::dip_check(window, 2., 3.)?
@@ -51,11 +54,14 @@ pub async fn run_test_series(
         "step_check" => {
             const LEADING_PER_RUN: u8 = 1;
 
-            let mut result_vec = Vec::new();
+            let mut result_vec = Vec::with_capacity(cache.data.len());
+
+            // NOTE: Does data in each series have the same len?
+            let series_len = cache.data[0].len();
+
             for i in 0..cache.data.len() {
                 result_vec.push(
-                    cache.data[i]
-                        [(cache.num_leading_points - LEADING_PER_RUN).into()..cache.data[i].len()]
+                    cache.data[i][(cache.num_leading_points - LEADING_PER_RUN).into()..series_len]
                         .windows((LEADING_PER_RUN + 1).into())
                         .map(|window| {
                             olympian::step_check(window, 2., 3.)?
@@ -108,7 +114,7 @@ pub async fn run_test_spatial(
             let mut result_vec = Vec::new();
             let n = cache.data.len();
             for i in 0..cache.data[0].len() {
-                // TODO: change `buddy_check` to accept Option<f32>
+                // TODO: change `buddy_check` to accept Option<f32>?
                 let inner: Vec<f32> = cache.data.iter().map(|v| v[i].unwrap()).collect();
                 result_vec.push(
                     olympian::buddy_check(
@@ -135,6 +141,7 @@ pub async fn run_test_spatial(
             let n = cache.data.len();
 
             for i in 0..cache.data[0].len() {
+                // TODO: change `sct` to accept Option<f32>?
                 let inner: Vec<f32> = cache.data.iter().map(|v| v[i].unwrap()).collect();
                 result_vec.push(
                     olympian::sct(

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -111,9 +111,11 @@ pub async fn run_test_spatial(
 ) -> Result<ValidateSpatialResponse, Error> {
     let flags: Vec<Flag> = match test {
         "buddy_check" => {
-            let mut result_vec = Vec::new();
             let n = cache.data.len();
-            for i in 0..cache.data[0].len() {
+
+            let series_len = cache.data[0].len();
+            let mut result_vec = Vec::with_capacity(series_len);
+            for i in 0..series_len {
                 // TODO: change `buddy_check` to accept Option<f32>?
                 let inner: Vec<f32> = cache.data.iter().map(|v| v[i].unwrap()).collect();
                 result_vec.push(
@@ -137,10 +139,11 @@ pub async fn run_test_spatial(
             result_vec[0].clone()
         }
         "sct" => {
-            let mut result_vec = Vec::new();
             let n = cache.data.len();
 
-            for i in 0..cache.data[0].len() {
+            let series_len = cache.data[0].len();
+            let mut result_vec = Vec::with_capacity(series_len);
+            for i in 0..series_len {
                 // TODO: change `sct` to accept Option<f32>?
                 let inner: Vec<f32> = cache.data.iter().map(|v| v[i].unwrap()).collect();
                 result_vec.push(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,9 +129,7 @@ pub(crate) mod pb {
 #[doc(hidden)]
 pub mod dev_utils {
     use crate::{
-        data_switch::{
-            self, DataConnector, Polygon, SeriesCache, SpatialCache, Timerange, Timestamp,
-        },
+        data_switch::{self, DataCache, DataConnector, Polygon, Timerange, Timestamp},
         Dag,
     };
     use async_trait::async_trait;
@@ -152,20 +150,26 @@ pub mod dev_utils {
             data_id: &str,
             _timespec: Timerange,
             num_leading_points: u8,
-        ) -> Result<SeriesCache, data_switch::Error> {
+        ) -> Result<DataCache, data_switch::Error> {
             match data_id {
-                "single" => black_box(Ok(SeriesCache {
-                    start_time: Timestamp(0),
-                    period: RelativeDuration::minutes(5),
-                    data: vec![Some(1.); self.data_len_single],
+                "single" => black_box(Ok(DataCache::new(
+                    vec![0.; 1],
+                    vec![0.; 1],
+                    vec![0.; 1],
+                    Timestamp(0),
+                    RelativeDuration::minutes(5),
                     num_leading_points,
-                })),
-                "series" => black_box(Ok(SeriesCache {
-                    start_time: Timestamp(0),
-                    period: RelativeDuration::minutes(5),
-                    data: vec![Some(1.); self.data_len_spatial],
+                    vec![vec![Some(1.); self.data_len_single]; 1],
+                ))),
+                "series" => black_box(Ok(DataCache::new(
+                    vec![0.; 1],
+                    vec![0.; 1],
+                    vec![0.; 1],
+                    Timestamp(0),
+                    RelativeDuration::minutes(5),
                     num_leading_points,
-                })),
+                    vec![vec![Some(1.); self.data_len_spatial]; 1],
+                ))),
                 _ => panic!("unknown data_id"),
             }
         }
@@ -175,8 +179,8 @@ pub mod dev_utils {
             _data_id: &str,
             _polygon: &Polygon,
             _timestamp: Timestamp,
-        ) -> Result<SpatialCache, data_switch::Error> {
-            black_box(Ok(SpatialCache::new(
+        ) -> Result<DataCache, data_switch::Error> {
+            black_box(Ok(DataCache::new(
                 (0..self.data_len_spatial)
                     .map(|i| ((i as f32).powi(2) * 0.001) % 3.)
                     .collect(),
@@ -184,7 +188,10 @@ pub mod dev_utils {
                     .map(|i| ((i as f32 + 1.).powi(2) * 0.001) % 3.)
                     .collect(),
                 vec![1.; self.data_len_spatial],
-                vec![1.; self.data_len_spatial],
+                Timestamp(0),
+                RelativeDuration::minutes(5),
+                0,
+                vec![vec![Some(1.); 1]; self.data_len_spatial],
             )))
         }
     }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,6 +1,6 @@
 use crate::{
     dag::{Dag, NodeId},
-    data_switch::{self, DataSwitch, Polygon, SeriesCache, SpatialCache, Timerange, Timestamp},
+    data_switch::{self, DataCache, DataSwitch, Polygon, Timerange, Timestamp},
     harness,
     // TODO: rethink this dependency?
     pb::{ValidateSeriesResponse, ValidateSpatialResponse},
@@ -92,7 +92,7 @@ impl<'a> Scheduler<'a> {
 
     fn schedule_tests_series(
         subdag: Dag<&'static str>,
-        data: SeriesCache,
+        data: DataCache,
     ) -> Receiver<Result<ValidateSeriesResponse, Error>> {
         // spawn and channel are required if you want handle "disconnect" functionality
         // the `out_stream` will not be polled after client disconnect
@@ -155,7 +155,7 @@ impl<'a> Scheduler<'a> {
     // closures drop?
     fn schedule_tests_spatial(
         subdag: Dag<&'static str>,
-        data: SpatialCache,
+        data: DataCache,
     ) -> Receiver<Result<ValidateSpatialResponse, Error>> {
         // spawn and channel are required if you want handle "disconnect" functionality
         // the `out_stream` will not be polled after client disconnect


### PR DESCRIPTION
Closes #70.

I left some comments that I guess I'll figure out when I start working on the next parts of the refactor.

@intarga, what do you think about having a `Vec<Location>` instead of the three `Vec<lat>`, `Vec<lon>`, `Vec<elev>`?
It would simplify the DataCache::new method and the run_test_spatial function, but it also requires changes in SpatialTree, and probably somewhere else I'm not aware of :sweat_smile: 