### PR TITLE
Update to Olympian 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aligned-vec"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
-
-[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,29 +102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
-name = "assert2"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf98d1183406dcb8f8b545e1f24829d75c1a9d35eec4b86309a22aa8b6d8e95"
-dependencies = [
- "assert2-macros",
- "is-terminal",
- "yansi",
-]
-
-[[package]]
-name = "assert2-macros"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c55bdf3e6f792f8f1c750bb6886b7ca40fa5a354ddb7a4dee550b93985a9235"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,15 +132,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.86",
-]
-
-[[package]]
-name = "atomic-polyfill"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
-dependencies = [
- "critical-section",
 ]
 
 [[package]]
@@ -263,6 +225,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,9 +241,23 @@ checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "bytemuck"
-version = "1.13.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.86",
+]
 
 [[package]]
 name = "byteorder"
@@ -432,6 +417,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,22 +461,6 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
-]
-
-[[package]]
-name = "critical-section"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -525,6 +503,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "csv"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,10 +534,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "dyn-stack"
-version = "0.9.0"
+name = "dbgf"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24269739c7c175bc12130622ef1a60b9ab2d5b30c0b9ce5110cd406d7fd497bc"
+checksum = "e6ca96b45ca70b8045e0462f191bd209fcb3c3bfe8dbfb1257ada54c4dd59169"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "dyn-stack"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e53799688f5632f364f8fb387488dd05db9fe45db7011be066fc20e7027f8b"
 dependencies = [
  "bytemuck",
  "reborrow",
@@ -571,6 +575,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.86",
+]
+
+[[package]]
+name = "equator"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35da53b5a021d2484a7cc49b2ac7f2d840f8236a286f84202369bd338d761ea"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.86",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,41 +623,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "faer-core"
-version = "0.9.1"
+name = "faer"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e36300510f89c8c2c87b8b27a915956b83dcc82e6018302cbf63425add0bec8"
+checksum = "41543c4de4bfb32efdffdd75cbcca5ef41b800e8a811ea4a41fb9393c6ef3bc0"
 dependencies = [
- "aligned-vec",
- "assert2",
  "bytemuck",
  "coe-rs",
+ "dbgf",
  "dyn-stack",
+ "equator",
+ "faer-entity",
  "gemm",
- "num-complex",
- "num-traits",
- "pulp",
- "rayon",
- "reborrow",
- "seq-macro",
-]
-
-[[package]]
-name = "faer-lu"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2cb9d5e04ec2854a49d6f04ca613fdad8fe854c21c9ac21afc4b31dcee5fd2"
-dependencies = [
- "assert2",
- "bytemuck",
- "coe-rs",
- "dyn-stack",
- "faer-core",
+ "libm",
+ "matrixcompare",
+ "matrixcompare-core",
+ "nano-gemm",
+ "npyz",
  "num-complex",
  "num-traits",
  "paste",
- "pulp",
+ "rand",
+ "rand_distr",
  "rayon",
+ "reborrow",
+ "serde",
+]
+
+[[package]]
+name = "faer-entity"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9c752ab2bff6f0b9597c6a1adc0112f7fd41fb343bc5a009a6274ae9d32fd03"
+dependencies = [
+ "bytemuck",
+ "coe-rs",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "pulp",
  "reborrow",
 ]
 
@@ -758,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "gemm"
-version = "0.15.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf05244e1ab5f098f2303bb1cedc1d7ca17e8cb9cb8b08040c8233cf10fc6ec"
+checksum = "e400f2ffd14e7548356236c35dc39cad6666d833a852cb8a8f3f28029359bb03"
 dependencies = [
  "dyn-stack",
  "gemm-c32",
@@ -769,76 +809,73 @@ dependencies = [
  "gemm-f16",
  "gemm-f32",
  "gemm-f64",
- "lazy_static",
  "num-complex",
  "num-traits",
  "paste",
  "raw-cpuid",
- "rayon",
  "seq-macro",
 ]
 
 [[package]]
 name = "gemm-c32"
-version = "0.15.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d84942bd86c6e176f33f80d96311e078097cd93039cc5feec1b43ddefae749f"
+checksum = "10dc4a6176c8452d60eac1a155b454c91c668f794151a303bf3c75ea2874812d"
 dependencies = [
  "dyn-stack",
  "gemm-common",
- "lazy_static",
  "num-complex",
  "num-traits",
  "paste",
  "raw-cpuid",
- "rayon",
  "seq-macro",
 ]
 
 [[package]]
 name = "gemm-c64"
-version = "0.15.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2bcdc95440f12836640e8fd4df0050a2c4b34a0c01d92f8050ae886557761fc"
+checksum = "cc2032ce2c0bb150da0256338759a6fb01ca056f6dfe28c4d14af32d7f878f6f"
 dependencies = [
  "dyn-stack",
  "gemm-common",
- "lazy_static",
  "num-complex",
  "num-traits",
  "paste",
  "raw-cpuid",
- "rayon",
  "seq-macro",
 ]
 
 [[package]]
 name = "gemm-common"
-version = "0.15.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912249fe0356806062ab2672c9cf340521732ef8d317d851d122ae6922ddd71c"
+checksum = "90fd234fc525939654f47b39325fd5f55e552ceceea9135f3aa8bdba61eabef6"
 dependencies = [
+ "bytemuck",
  "dyn-stack",
- "lazy_static",
+ "half 2.3.1",
  "num-complex",
  "num-traits",
+ "once_cell",
  "paste",
+ "pulp",
  "raw-cpuid",
  "rayon",
  "seq-macro",
+ "sysctl",
 ]
 
 [[package]]
 name = "gemm-f16"
-version = "0.15.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6820d54fd53eead15a3024c06f403a1eb082a77e0670eb78d89ad22d6f5ad9a"
+checksum = "3fc3652651f96a711d46b8833e1fac27a864be4bdfa81a374055f33ddd25c0c6"
 dependencies = [
  "dyn-stack",
  "gemm-common",
  "gemm-f32",
  "half 2.3.1",
- "lazy_static",
  "num-complex",
  "num-traits",
  "paste",
@@ -849,36 +886,42 @@ dependencies = [
 
 [[package]]
 name = "gemm-f32"
-version = "0.15.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc60558103e48ad7c953cee1334c30f3efb47f63105882ff6346d7418a6ca2fc"
+checksum = "acbc51c44ae3defd207e6d9416afccb3c4af1e7cef5e4960e4c720ac4d6f998e"
 dependencies = [
  "dyn-stack",
  "gemm-common",
- "lazy_static",
  "num-complex",
  "num-traits",
  "paste",
  "raw-cpuid",
- "rayon",
  "seq-macro",
 ]
 
 [[package]]
 name = "gemm-f64"
-version = "0.15.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e7cf971e94e5e86729881f1a9b6d4e55a74207daf5f466a936d6ab4e014a861"
+checksum = "3f37fc86e325c2415a4d0cab8324a0c5371ec06fc7d2f9cb1636fcfc9536a8d8"
 dependencies = [
  "dyn-stack",
  "gemm-common",
- "lazy_static",
  "num-complex",
  "num-traits",
  "paste",
  "raw-cpuid",
- "rayon",
  "seq-macro",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -929,6 +972,7 @@ version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
@@ -936,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "hash32"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
@@ -957,14 +1001,11 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heapless"
-version = "0.7.16"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "atomic-polyfill",
  "hash32",
- "rustc_version",
- "spin",
  "stable_deref_trait",
 ]
 
@@ -1183,9 +1224,9 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libm"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1214,6 +1255,22 @@ name = "matchit"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+
+[[package]]
+name = "matrixcompare"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37832ba820e47c93d66b4360198dccb004b43c74abc3ac1ce1fed54e65a80445"
+dependencies = [
+ "matrixcompare-core",
+ "num-traits",
+]
+
+[[package]]
+name = "matrixcompare-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0bdabb30db18805d5290b3da7ceaccbddba795620b86c02145d688e04900a73"
 
 [[package]]
 name = "memchr"
@@ -1292,6 +1349,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "nano-gemm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f563548d38f390ef9893e4883ec38c1fb312f569e98d76bededdd91a3b41a043"
+dependencies = [
+ "equator",
+ "nano-gemm-c32",
+ "nano-gemm-c64",
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+ "nano-gemm-f32",
+ "nano-gemm-f64",
+ "num-complex",
+]
+
+[[package]]
+name = "nano-gemm-c32"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40449e57a5713464c3a1208c4c3301c8d29ee1344711822cf022bc91373a91b"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+ "num-complex",
+]
+
+[[package]]
+name = "nano-gemm-c64"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743a6e6211358fba85d1009616751e4107da86f4c95b24e684ce85f25c25b3bf"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+ "num-complex",
+]
+
+[[package]]
+name = "nano-gemm-codegen"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "963bf7c7110d55430169dc74c67096375491ed580cd2ef84842550ac72e781fa"
+
+[[package]]
+name = "nano-gemm-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe3fc4f83ae8861bad79dc3c016bd6b0220da5f9de302e07d3112d16efc24aa6"
+
+[[package]]
+name = "nano-gemm-f32"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3681b7ce35658f79da94b7f62c60a005e29c373c7111ed070e3bf64546a8bb"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+]
+
+[[package]]
+name = "nano-gemm-f64"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc1e619ed04d801809e1f63e61b669d380c4119e8b0cdd6ed184c6b111f046d8"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,6 +1437,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "npyz"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13f27ea175875c472b3df61ece89a6d6ef4e0627f43704e400c782f174681ebd"
+dependencies = [
+ "byteorder",
+ "num-bigint",
+ "py_literal",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,33 +1458,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.4.3"
+name = "num-bigint"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "bytemuck",
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -1360,14 +1508,12 @@ dependencies = [
 
 [[package]]
 name = "olympian"
-version = "0.3.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b17997be72de2d7da4f18ca0b166c240ca1b54466611546129ea2a923f2282"
+checksum = "bd25aaba52e6ed10b87a0e19f3161157b78bebdb85b9e1538252c37b6073fb29"
 dependencies = [
- "dyn-stack",
- "faer-core",
- "faer-lu",
- "reborrow",
+ "chronoutil",
+ "faer",
  "rstar",
  "thiserror",
 ]
@@ -1459,15 +1605,60 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+
+[[package]]
+name = "pest"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.86",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "petgraph"
@@ -1627,12 +1818,27 @@ dependencies = [
 
 [[package]]
 name = "pulp"
-version = "0.13.1"
+version = "0.18.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35403e0126ec324b0eba8f65254eb07ac9502650711dd3933f4ea5e5a809eaee"
+checksum = "a0a01a0dc67cf4558d279f0c25b0962bd08fc6dec0137699eae304103e882fe6"
 dependencies = [
  "bytemuck",
+ "libm",
  "num-complex",
+ "reborrow",
+]
+
+[[package]]
+name = "py_literal"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "102df7a3d46db9d3891f178dcc826dc270a6746277a9ae6436f8d29fd490a8e1"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-traits",
+ "pest",
+ "pest_derive",
 ]
 
 [[package]]
@@ -1675,6 +1881,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1685,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -1695,21 +1911,19 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
 name = "reborrow"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2962bf2e1f971c53ef59b2d7ca51d6a5e5c4a9d2be47eb1f661a321a4da85888"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
@@ -1815,9 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "rstar"
-version = "0.9.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b40f1bfe5acdab44bc63e6699c28b74f75ec43afb59f3eda01e145aff86a25fa"
+checksum = "133315eb94c7b1e8d0cb097e5a710d850263372fd028fff18969de708afc7008"
 dependencies = [
  "heapless",
  "num-traits",
@@ -1829,15 +2043,6 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rustix"
@@ -1915,12 +2120,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
-
-[[package]]
 name = "seq-macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1980,6 +2179,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,15 +2243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2080,6 +2281,20 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sysctl"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea"
+dependencies = [
+ "bitflags 2.4.1",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror",
+ "walkdir",
+]
 
 [[package]]
 name = "system-configuration"
@@ -2449,6 +2664,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2497,6 +2724,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2800,9 +3033,3 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "yansi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ tonic = "0.7.2"
 tokio = { version = "1.41.0", features = ["full"] }
 prost = "0.10.4"
 prost-types = "0.10"
-olympian = "0.3.2"
+olympian = "0.4.2"
 tracing = "0.1.16"
 tracing-subscriber = { version = "0.3", features = ["tracing-log"] }
 futures = "0.3.31"

--- a/met_connectors/src/lustre_netatmo/mod.rs
+++ b/met_connectors/src/lustre_netatmo/mod.rs
@@ -3,7 +3,7 @@ use chrono::prelude::*;
 use chronoutil::RelativeDuration;
 use rove::{
     data_switch,
-    data_switch::{DataCache, DataConnector, SpaceSpec, TimeSpec, Timestamp},
+    data_switch::{DataCache, DataConnector, SpaceSpec, TimeSpec, Timeseries, Timestamp},
 };
 use serde::Deserialize;
 use std::{fs::File, io};
@@ -60,16 +60,16 @@ fn read_netatmo(timestamp: Timestamp) -> Result<DataCache, data_switch::Error> {
             lats.push(record.lat);
             lons.push(record.lon);
             elevs.push(record.elev);
-            values.push((
+            values.push(Timeseries {
                 // would be nice if we could come up with better identifiers for this
-                format!("({},{})", record.lat, record.lon),
-                vec![Some(record.value)],
-            ));
+                tag: format!("({},{})", record.lat, record.lon),
+                values: vec![Some(record.value)],
+            });
         }
     }
 
     Ok(DataCache::new(
-        lats, lons, elevs, timestamp, period, 0, 0, values,
+        values, lats, lons, elevs, timestamp, period, 0, 0,
     ))
 }
 

--- a/met_connectors/src/lustre_netatmo/mod.rs
+++ b/met_connectors/src/lustre_netatmo/mod.rs
@@ -47,7 +47,7 @@ fn read_netatmo(timestamp: Timestamp) -> Result<DataCache, data_switch::Error> {
     let mut lats = Vec::new();
     let mut lons = Vec::new();
     let mut elevs = Vec::new();
-    let mut values = Vec::new();
+    let mut data = Vec::new();
 
     let mut rdr = csv::ReaderBuilder::new().delimiter(b';').from_reader(file);
     for result in rdr.deserialize() {
@@ -60,7 +60,7 @@ fn read_netatmo(timestamp: Timestamp) -> Result<DataCache, data_switch::Error> {
             lats.push(record.lat);
             lons.push(record.lon);
             elevs.push(record.elev);
-            values.push(Timeseries {
+            data.push(Timeseries {
                 // would be nice if we could come up with better identifiers for this
                 tag: format!("({},{})", record.lat, record.lon),
                 values: vec![Some(record.value)],
@@ -69,7 +69,7 @@ fn read_netatmo(timestamp: Timestamp) -> Result<DataCache, data_switch::Error> {
     }
 
     Ok(DataCache::new(
-        values, lats, lons, elevs, timestamp, period, 0, 0,
+        data, lats, lons, elevs, timestamp, period, 0, 0,
     ))
 }
 

--- a/proto/rove.proto
+++ b/proto/rove.proto
@@ -6,9 +6,7 @@ import "google/protobuf/empty.proto";
 package rove;
 
 service Rove {
-  // TODO: should we reconsider allowing results to stream, in favour of a more
-  // space efficient response format?
-  rpc Validate (ValidateRequest) returns (stream ValidateResponse) {}
+  rpc Validate (ValidateRequest) returns (ValidateResponse) {}
 }
 
 message GeoPoint {
@@ -62,18 +60,26 @@ message ValidateRequest {
   optional string extra_spec = 10;
 }
 
-message TestResult {
-  google.protobuf.Timestamp time = 1;
+message FlagSeries {
   // data source defined identifier, it's recommended to use this to identify
   // a timeseries/station/location as appropriate
-  string identifier = 2;
-  Flag flag = 3;
+  string id = 1;
+  // flags indicating the results of running the check on each element of the
+  // given timeseries. The time in the timeseries each flag applies to is 
+  // `start_time` + (`time_resolution` * index), where `start_time` and
+  // `time_resolution` are arguments given in the `ValidateRequest`
+  repeated Flag flags = 2;
+}
+
+message CheckResult {
+  // name of the check these results apply to
+  string check = 1;
+  // each of these encodes the results for one timeseries
+  repeated FlagSeries flag_series = 2;
 }
 
 message ValidateResponse {
-  // name of the test this flag is from
-  string test = 1;
-  // results for each data point, paired with timestamp and an identifier to
-  // identify the point
-  repeated TestResult results = 2;
+  // each of these contain the results from running a single check on the
+  // requested data, further broken down by timeseries
+  repeated CheckResult results = 1;
 }

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -5,12 +5,14 @@ use crate::{
 };
 use chrono::prelude::*;
 use chronoutil::DateRule;
+use olympian::{
+    checks::{
+        series::{spike_check_cache, step_check_cache},
+        spatial::{buddy_check_cache, sct_cache, BuddyCheckArgs, SctArgs},
+    },
+    SingleOrVec, Timeseries,
+};
 use thiserror::Error;
-
-pub const SPIKE_LEADING_PER_RUN: u8 = 1;
-pub const SPIKE_TRAILING_PER_RUN: u8 = 1;
-pub const STEP_LEADING_PER_RUN: u8 = 1;
-pub const STEP_TRAILING_PER_RUN: u8 = 0;
 
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
@@ -26,150 +28,48 @@ pub enum Error {
 pub fn run_test(step: &PipelineStep, cache: &DataCache) -> Result<ValidateResponse, Error> {
     let step_name = step.name.to_string();
 
-    let flags: Vec<(String, Vec<Flag>)> = match &step.check {
-        CheckConf::SpikeCheck(conf) => {
-            const LEADING_PER_RUN: u8 = SPIKE_LEADING_PER_RUN;
-            const TRAILING_PER_RUN: u8 = SPIKE_TRAILING_PER_RUN;
-
-            // TODO: use par_iter?
-
-            let mut result_vec = Vec::with_capacity(cache.data.len());
-
-            let series_len = cache.data[0].1.len();
-
-            for i in 0..cache.data.len() {
-                result_vec.push((
-                    cache.data[i].0.clone(),
-                    cache.data[i].1[(cache.num_leading_points - LEADING_PER_RUN).into()
-                        ..(series_len - (cache.num_trailing_points - TRAILING_PER_RUN) as usize)]
-                        .windows((LEADING_PER_RUN + 1 + TRAILING_PER_RUN).into())
-                        .map(|window| {
-                            // TODO: the "high" param is hardcoded for now, but should be removed
-                            // from olympian
-                            olympian::dip_check(window, 2., conf.max)?
-                                .try_into()
-                                .map_err(Error::UnknownFlag)
-                        })
-                        .collect::<Result<Vec<Flag>, Error>>()?,
-                ))
-            }
-            result_vec
-        }
-        CheckConf::StepCheck(conf) => {
-            const LEADING_PER_RUN: u8 = STEP_LEADING_PER_RUN;
-            const TRAILING_PER_RUN: u8 = STEP_TRAILING_PER_RUN;
-
-            let mut result_vec = Vec::with_capacity(cache.data.len());
-
-            // NOTE: Does data in each series have the same len?
-            let series_len = cache.data[0].1.len();
-
-            for i in 0..cache.data.len() {
-                result_vec.push((
-                    cache.data[i].0.clone(),
-                    cache.data[i].1[(cache.num_leading_points - LEADING_PER_RUN).into()
-                        ..(series_len - (cache.num_trailing_points - TRAILING_PER_RUN) as usize)]
-                        .windows((LEADING_PER_RUN + 1).into())
-                        .map(|window| {
-                            // TODO: the "high" param is hardcoded for now, but should be removed
-                            // from olympian
-                            olympian::step_check(window, 2., conf.max)?
-                                .try_into()
-                                .map_err(Error::UnknownFlag)
-                        })
-                        .collect::<Result<Vec<Flag>, Error>>()?,
-                ))
-            }
-            result_vec
-        }
-        CheckConf::BuddyCheck(conf) => {
-            let n = cache.data.len();
-
-            let series_len = cache.data[0].1.len();
-
-            let mut result_vec: Vec<(String, Vec<Flag>)> = cache
-                .data
-                .iter()
-                .map(|ts| (ts.0.clone(), Vec::with_capacity(series_len)))
-                .collect();
-
-            for i in (cache.num_leading_points as usize)
-                ..(series_len - cache.num_trailing_points as usize)
-            {
-                // TODO: change `buddy_check` to accept Option<f32>?
-                let inner: Vec<f32> = cache.data.iter().map(|v| v.1[i].unwrap()).collect();
-
-                let spatial_result = olympian::buddy_check(
-                    &cache.rtree,
-                    &inner,
-                    &conf.radii,         // &vec![5000.; n],
-                    &conf.nums_min,      // &vec![2; n],
-                    conf.threshold,      // 2.,
-                    conf.max_elev_diff,  // 200.,
-                    conf.elev_gradient,  // 0.,
-                    conf.min_std,        // 1.,
-                    conf.num_iterations, // 2,
-                    // TODO: should we be setting this dynamically? from where?
-                    &vec![true; n],
-                )?;
-
-                for (i, flag) in spatial_result.into_iter().map(Flag::try_from).enumerate() {
-                    result_vec[i].1.push(flag.map_err(Error::UnknownFlag)?);
-                }
-            }
-            result_vec
-        }
-        CheckConf::Sct(conf) => {
-            // TODO: evaluate whether we will need this to extend param vectors from conf
-            // if the checks accept single values (which they should) then we don't need this.
-            // anyway I think if we have dynamic values for these we can match them to the data
-            // when fetching them.
-            let n = cache.data.len();
-
-            let series_len = cache.data[0].1.len();
-
-            let mut result_vec: Vec<(String, Vec<Flag>)> = cache
-                .data
-                .iter()
-                .map(|ts| (ts.0.clone(), Vec::with_capacity(series_len)))
-                .collect();
-
-            for i in (cache.num_leading_points as usize)
-                ..(series_len - cache.num_trailing_points as usize)
-            {
-                // TODO: change `sct` to accept Option<f32>?
-                let inner: Vec<f32> = cache.data.iter().map(|v| v.1[i].unwrap()).collect();
-                // TODO: make it so olympian can accept the conf as one param?
-                let spatial_result = olympian::sct(
-                    &cache.rtree,
-                    &inner,
-                    conf.num_min,              // 5,
-                    conf.num_max,              // 100,
-                    conf.inner_radius,         // 50000.,
-                    conf.outer_radius,         // 150000.,
-                    conf.num_iterations,       // 5,
-                    conf.num_min_prof,         // 20,
-                    conf.min_elev_diff,        // 200.,
-                    conf.min_horizontal_scale, // 10000.,
-                    conf.vertical_scale,       // 200.,
-                    // TODO: we shouldn't need to extend these vectors, it should be handled
-                    // better in olympian
-                    &vec![conf.pos[0]; n],  // &vec![4.; n],
-                    &vec![conf.neg[0]; n],  // &vec![8.; n],
-                    &vec![conf.eps2[0]; n], // &vec![0.5; n],
-                    None,
-                )?;
-
-                for (i, flag) in spatial_result.into_iter().map(Flag::try_from).enumerate() {
-                    result_vec[i].1.push(flag.map_err(Error::UnknownFlag)?);
-                }
-            }
-            result_vec
-        }
+    let flags: Vec<Timeseries<olympian::Flag>> = match &step.check {
+        CheckConf::SpikeCheck(conf) => spike_check_cache(cache, conf.max)?,
+        CheckConf::StepCheck(conf) => step_check_cache(cache, conf.max)?,
+        CheckConf::BuddyCheck(conf) => buddy_check_cache(
+            cache,
+            // TODO: from/into impl?
+            &BuddyCheckArgs {
+                radii: SingleOrVec::Single(conf.radii),
+                min_buddies: SingleOrVec::Single(conf.min_buddies),
+                threshold: conf.threshold,
+                max_elev_diff: conf.max_elev_diff,
+                elev_gradient: conf.elev_gradient,
+                min_std: conf.min_std,
+                num_iterations: conf.num_iterations,
+            },
+            None,
+        )?,
+        CheckConf::Sct(conf) => sct_cache(
+            cache,
+            &SctArgs {
+                num_min: conf.num_min,
+                num_max: conf.num_max,
+                inner_radius: conf.inner_radius,
+                outer_radius: conf.outer_radius,
+                num_iterations: conf.num_iterations,
+                num_min_prof: conf.num_min_prof,
+                min_elev_diff: conf.min_elev_diff,
+                min_horizontal_scale: conf.min_horizontal_scale,
+                vertical_scale: conf.vertical_scale,
+                pos: SingleOrVec::Single(conf.pos),
+                neg: SingleOrVec::Single(conf.neg),
+                eps2: SingleOrVec::Single(conf.eps2),
+            },
+            None,
+        )?,
         _ => {
             // used for integration testing
             if step_name.starts_with("test") {
-                vec![("test".to_string(), vec![Flag::Inconclusive])]
+                vec![Timeseries {
+                    tag: "test".to_string(),
+                    values: vec![olympian::Flag::Inconclusive],
+                }]
             } else {
                 return Err(Error::InvalidTestName(step_name));
             }
@@ -185,20 +85,23 @@ pub fn run_test(step: &PipelineStep, cache: &DataCache) -> Result<ValidateRespon
         .into_iter()
         .flat_map(|flag_series| {
             flag_series
-                .1
+                .values
                 .into_iter()
                 .zip(date_rule)
-                .zip(std::iter::repeat(flag_series.0))
+                .zip(std::iter::repeat(flag_series.tag))
         })
-        .map(|((flag, time), identifier)| TestResult {
-            time: Some(prost_types::Timestamp {
-                seconds: time.timestamp(),
-                nanos: 0,
-            }),
-            identifier,
-            flag: flag.into(),
+        .map(|((flag, time), identifier)| {
+            let flag: Flag = flag.try_into().map_err(Error::UnknownFlag)?;
+            Ok(TestResult {
+                time: Some(prost_types::Timestamp {
+                    seconds: time.timestamp(),
+                    nanos: 0,
+                }),
+                identifier,
+                flag: flag.into(),
+            })
         })
-        .collect();
+        .collect::<Result<Vec<TestResult>, Error>>()?;
 
     Ok(ValidateResponse {
         test: step_name,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ pub(crate) mod pb {
 #[doc(hidden)]
 pub mod dev_utils {
     use crate::{
-        data_switch::{self, DataCache, DataConnector, SpaceSpec, TimeSpec, Timestamp},
+        data_switch::{self, DataCache, DataConnector, SpaceSpec, TimeSpec, Timeseries, Timestamp},
         pipeline::{derive_num_leading_trailing, Pipeline},
     };
     use async_trait::async_trait;
@@ -163,6 +163,13 @@ pub mod dev_utils {
                     // TODO: should we maybe be using time_spec for these instead of data_id?
                     // maybe something to come back to when we finalize the format of time_spec
                     "single" => black_box(Ok(DataCache::new(
+                        vec![
+                            Timeseries {
+                                tag: "test".to_string(),
+                                values: vec![Some(1.); self.data_len_single]
+                            };
+                            1
+                        ],
                         vec![0.; 1],
                         vec![0.; 1],
                         vec![0.; 1],
@@ -170,9 +177,15 @@ pub mod dev_utils {
                         RelativeDuration::minutes(5),
                         num_leading_points,
                         num_trailing_points,
-                        vec![("test".to_string(), vec![Some(1.); self.data_len_single]); 1],
                     ))),
                     "series" => black_box(Ok(DataCache::new(
+                        vec![
+                            Timeseries {
+                                tag: "test".to_string(),
+                                values: vec![Some(1.); self.data_len_series]
+                            };
+                            1
+                        ],
                         vec![0.; 1],
                         vec![0.; 1],
                         vec![0.; 1],
@@ -180,11 +193,22 @@ pub mod dev_utils {
                         RelativeDuration::minutes(5),
                         num_leading_points,
                         num_trailing_points,
-                        vec![("test".to_string(), vec![Some(1.); self.data_len_series]); 1],
                     ))),
                     _ => panic!("unknown data_id"),
                 },
                 SpaceSpec::All => black_box(Ok(DataCache::new(
+                    vec![
+                        Timeseries {
+                            tag: "test".to_string(),
+                            values: vec![
+                                Some(1.);
+                                num_leading_points as usize
+                                    + 1
+                                    + num_trailing_points as usize
+                            ]
+                        };
+                        self.data_len_spatial
+                    ],
                     (0..self.data_len_spatial)
                         .map(|i| ((i as f32).powi(2) * 0.001) % 3.)
                         .collect(),
@@ -196,16 +220,6 @@ pub mod dev_utils {
                     RelativeDuration::minutes(5),
                     num_leading_points,
                     num_trailing_points,
-                    vec![
-                        (
-                            "test".to_string(),
-                            vec![
-                                Some(1.);
-                                num_leading_points as usize + 1 + num_trailing_points as usize
-                            ]
-                        );
-                        self.data_len_spatial
-                    ],
                 ))),
                 SpaceSpec::Polygon(_) => unimplemented!(),
             }
@@ -230,8 +244,8 @@ pub mod dev_utils {
                     name = "buddy_check"
                     [step.buddy_check]
                     max = 3
-                    radii = [5000.0]
-                    nums_min = [2]
+                    radii = 5000.0
+                    min_buddies = 2
                     threshold = 2.0
                     max_elev_diff = 200.0
                     elev_gradient = 0.0
@@ -250,9 +264,9 @@ pub mod dev_utils {
                     min_elev_diff = 200.0
                     min_horizontal_scale = 10000.0
                     vertical_scale = 200.0
-                    pos = [4.0]
-                    neg = [8.0]
-                    eps2 = [0.5]
+                    pos = 4.0
+                    neg = 8.0
+                    eps2 = 0.5
             "#,
         )
         .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 //!
 //!     let rove_scheduler = Scheduler::new(construct_hardcoded_pipeline(), data_switch);
 //!
-//!     let mut rx = rove_scheduler.validate_direct(
+//!     let response = rove_scheduler.validate_direct(
 //!         "my_data_source",
 //!         &vec!["my_backing_source"],
 //!         &TimeSpec::new(
@@ -76,17 +76,9 @@
 //!         None,
 //!     ).await?;
 //!
-//!     while let Some(response) = rx.recv().await {
-//!         match response {
-//!             Ok(inner) => {
-//!                 println!("\ntest name: {}\n", inner.test);
-//!                 for result in inner.results {
-//!                     println!("timestamp: {}", result.time.unwrap().seconds);
-//!                     println!("flag: {}", result.flag);
-//!                 }
-//!             }
-//!             Err(e) => println!("uh oh, got an error: {}", e),
-//!         }
+//!     for result in response {
+//!         println!("check: {}", result.check);
+//!         println!("flags: {:?}", result.results);
 //!     }
 //!
 //!     Ok(())
@@ -97,6 +89,7 @@
 
 pub mod data_switch;
 mod harness;
+pub(crate) mod pb;
 mod pipeline;
 mod scheduler;
 mod server;
@@ -109,27 +102,6 @@ pub use server::start_server;
 
 #[doc(hidden)]
 pub use server::start_server_unix_listener;
-
-pub(crate) mod pb {
-    tonic::include_proto!("rove");
-
-    impl TryFrom<olympian::Flag> for Flag {
-        type Error = String;
-
-        fn try_from(item: olympian::Flag) -> Result<Self, Self::Error> {
-            match item {
-                olympian::Flag::Pass => Ok(Self::Pass),
-                olympian::Flag::Fail => Ok(Self::Fail),
-                olympian::Flag::Warn => Ok(Self::Warn),
-                olympian::Flag::Inconclusive => Ok(Self::Inconclusive),
-                olympian::Flag::Invalid => Ok(Self::Invalid),
-                olympian::Flag::DataMissing => Ok(Self::DataMissing),
-                olympian::Flag::Isolated => Ok(Self::Isolated),
-                _ => Err(format!("{:?}", item)),
-            }
-        }
-    }
-}
 
 #[doc(hidden)]
 pub mod dev_utils {

--- a/src/pb.rs
+++ b/src/pb.rs
@@ -1,0 +1,58 @@
+//! Generated proto bindings, plus handwritten trait impls for proto types
+
+use crate::{data_switch, harness};
+
+tonic::include_proto!("rove");
+
+impl TryFrom<olympian::Flag> for Flag {
+    type Error = String;
+
+    fn try_from(item: olympian::Flag) -> Result<Self, Self::Error> {
+        match item {
+            olympian::Flag::Pass => Ok(Self::Pass),
+            olympian::Flag::Fail => Ok(Self::Fail),
+            olympian::Flag::Warn => Ok(Self::Warn),
+            olympian::Flag::Inconclusive => Ok(Self::Inconclusive),
+            olympian::Flag::Invalid => Ok(Self::Invalid),
+            olympian::Flag::DataMissing => Ok(Self::DataMissing),
+            olympian::Flag::Isolated => Ok(Self::Isolated),
+            _ => Err(format!("{:?}", item)),
+        }
+    }
+}
+
+impl TryFrom<data_switch::Timeseries<olympian::Flag>> for FlagSeries {
+    type Error = String;
+
+    fn try_from(value: data_switch::Timeseries<olympian::Flag>) -> Result<Self, Self::Error> {
+        let flags = value
+            .values
+            .into_iter()
+            .map(|flag| {
+                let flag: Flag = flag
+                    .try_into()
+                    .map_err(|e| format!("unrecognized flag: {:?}", e))?;
+                Ok(flag.into())
+            })
+            .collect::<Result<Vec<i32>, String>>()?;
+        Ok(Self {
+            id: value.tag,
+            flags,
+        })
+    }
+}
+
+impl TryFrom<harness::CheckResult> for CheckResult {
+    type Error = String;
+
+    fn try_from(value: harness::CheckResult) -> Result<Self, Self::Error> {
+        Ok(Self {
+            check: value.check,
+            flag_series: value
+                .results
+                .into_iter()
+                .map(|ts| ts.try_into())
+                .collect::<Result<Vec<FlagSeries>, String>>()?,
+        })
+    }
+}

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,5 +1,5 @@
-use crate::harness::{
-    SPIKE_LEADING_PER_RUN, SPIKE_TRAILING_PER_RUN, STEP_LEADING_PER_RUN, STEP_TRAILING_PER_RUN,
+use olympian::checks::series::{
+    SPIKE_LEADING_PER_RUN, SPIKE_TRAILING_PER_RUN, STEP_LEADING_PER_RUN,
 };
 use serde::Deserialize;
 use std::{collections::HashMap, path::Path};
@@ -55,7 +55,7 @@ impl CheckConf {
             | CheckConf::Sct(_)
             | CheckConf::ModelConsistencyCheck(_)
             | CheckConf::Dummy => (0, 0),
-            CheckConf::StepCheck(_) => (STEP_LEADING_PER_RUN, STEP_TRAILING_PER_RUN),
+            CheckConf::StepCheck(_) => (STEP_LEADING_PER_RUN, 0),
             CheckConf::SpikeCheck(_) => (SPIKE_LEADING_PER_RUN, SPIKE_TRAILING_PER_RUN),
             CheckConf::FlatlineCheck(conf) => (conf.max, 0),
         }
@@ -95,8 +95,8 @@ pub struct FlatlineCheckConf {
 
 #[derive(Debug, Deserialize, PartialEq, Clone)]
 pub struct BuddyCheckConf {
-    pub radii: Vec<f32>,
-    pub nums_min: Vec<u32>,
+    pub radii: f32,
+    pub min_buddies: u32,
     pub threshold: f32,
     pub max_elev_diff: f32,
     pub elev_gradient: f32,
@@ -115,9 +115,9 @@ pub struct SctConf {
     pub min_elev_diff: f32,
     pub min_horizontal_scale: f32,
     pub vertical_scale: f32,
-    pub pos: Vec<f32>,
-    pub neg: Vec<f32>,
-    pub eps2: Vec<f32>,
+    pub pos: f32,
+    pub neg: f32,
+    pub eps2: f32,
     pub obs_to_check: Option<Vec<bool>>,
 }
 


### PR DESCRIPTION
Update to Olympian 0.4 so we can use the new checks, and their cache forms.

Since the return types from the checks have changed, it made sense to change the return type of `harness::run_check` too. And this change propagated up the call stack, fixing some outstanding todos along the way